### PR TITLE
Fixes Loading modules in fsx #2

### DIFF
--- a/playground.fsx
+++ b/playground.fsx
@@ -36,6 +36,7 @@ See the overview slide.
 // Task 5.4 - Point the JsonProvider to the web service
 //
 
+// #r "nuget:FSharp.Data"
 // open FSharp.Data
 // type WikipediaIO = JsonProvider<"http://api.geonames.org/findNearbyWikipediaJSON?lat=52.3676&lng=4.9041&username=dsyme">
 
@@ -54,6 +55,3 @@ See the overview slide.
 // A starting snippet is below
 
 // [ for x in info.Geonames -> x.Title ]
-
-
-


### PR DESCRIPTION
Not much to say, just added a commented line with the missing reference:
```F#
// #r "nuget:FSharp.Data"
// open FSharp.Data
// type WikipediaIO = JsonProvider<"http://api.geonames.org/findNearbyWikipediaJSON?lat=52.3676&lng=4.9041&username=dsyme">
```
I bet this isn't necessary if tooling is configured properly, but was for me (on arch linux)